### PR TITLE
chore: WIP upgrade anchor

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,6 +1,6 @@
 name: Build + Tests
 env:
-  cli-id: anchor-v0.18.dev-7b86aed-solana-1.8.5
+  cli-id: anchor-v0.22.dev-7b86aed-solana-1.8.5
 on:
   push:
     branches:
@@ -40,7 +40,7 @@ jobs:
 
       - id: install-anchor-cli
         if: steps.cache-cli-deps.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/project-serum/anchor --tag v0.18.2 anchor-cli --locked
+        run: cargo install --git https://github.com/project-serum/anchor --tag v0.22.0 anchor-cli --locked
 
   build:
     runs-on: ubuntu-latest
@@ -69,8 +69,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: npm install yarn -g
-      - run: npm install @project-serum/anchor -g
+      - run: npm install -g typescript
+      - run: npm install -g yarn
+      - run: npm install -g ts-mocha
+      - run: npm install -g @project-serum/anchor
       - run: yarn
       - run: solana-keygen new --no-bip39-passphrase
       - run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-access-control"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e53fd8d0aa034bb2e647c39eec4e399095438dbc83526949ac6a072e3c4ce7"
+checksum = "ed70c97998752288ce9840ae05dac6f7922856624d83bd8706941c363df5aa75"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-account"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "362b1b119372b38cdd45949bd8f09a8f5c56a701d49a747fc43d7a59393b647f"
+checksum = "7325a9ddeab60ace310dd920b354a6318d31b4dd6d8172a518de3b8d58601035"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -47,10 +47,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "anchor-attribute-error"
-version = "0.18.2"
+name = "anchor-attribute-constant"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c8be43ca34309afcafb24274bba6733b6b5d59be47f1cc11ef3afe9584e5cd"
+checksum = "1bfe53dec5dfe5742d949e7c21a3b813296c274183f4fbf669a070e45bd669c9"
+dependencies = [
+ "anchor-syn",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "anchor-attribute-error"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda765864694d1ddeff66e8d97b015760379dc7136474633f7db0ec04577fc8"
 dependencies = [
  "anchor-syn",
  "proc-macro2",
@@ -60,9 +71,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-event"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899640f277f8296da82d6505312b03a4cd4901c3c6d6fe8eb3ca2db33f26ebb9"
+checksum = "3ab29f55c9bf69f1e9a19838b5630204beaaddc4ca3ab8eed59a637e36b51428"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -73,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-interface"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f514a6502a0ad56f321df492f1c699ee8ad3912c6354acd087f3d28431a0fac4"
+checksum = "345ba1c992d29d3b666c4e5c8d8383d3291c4be3795dc13e218d59df55a08c21"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -87,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-program"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadc2f9bcaeb3be4a8efb76c455bc772b5d257c01796b415eb3aa4bd93ed43fe"
+checksum = "c2fd7fdf8c416d834650e7b8ef1db5746acc74c7333b3d9b3a385f5129e9b522"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -100,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-attribute-state"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adbff8f1a2b53a42ef547f3188e25f7e3d6933113ab0f94b11afb825eee80f47"
+checksum = "5426c71af1fcaa734d2f1dfde0f1e4ccc878be02707c767d6c9e88ef6686ecd5"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -113,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-derive-accounts"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458185d8bd23559f6ed35c4a7a7d0f83ac4d7837b2e790d90e50cafc9371503e"
+checksum = "2e597c70258147a5da1ca8801474e3a4a009214c1b7138cd863ef03eeba353a1"
 dependencies = [
  "anchor-syn",
  "anyhow",
@@ -126,19 +137,22 @@ dependencies = [
 
 [[package]]
 name = "anchor-lang"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dd615c2eb55d88de8800c46fa7ed51ef045d76ed669222a798976d0a447f59"
+checksum = "f3fab2e8305bfe8971e04e963a442a767d81f8d61e73effdbe04df73bb7f9feb"
 dependencies = [
  "anchor-attribute-access-control",
  "anchor-attribute-account",
+ "anchor-attribute-constant",
  "anchor-attribute-error",
  "anchor-attribute-event",
  "anchor-attribute-interface",
  "anchor-attribute-program",
  "anchor-attribute-state",
  "anchor-derive-accounts",
+ "arrayref",
  "base64 0.13.0",
+ "bincode",
  "borsh",
  "bytemuck",
  "solana-program",
@@ -147,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-spl"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d6c8fbc834319618581a4e19807a30e76326b9981abd069addb55acf0647db"
+checksum = "e49a20ac8743546bc76a247ff0a81ceb0cee7653b087ccb330bf3553d907d522"
 dependencies = [
  "anchor-lang",
  "solana-program",
@@ -159,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "anchor-syn"
-version = "0.18.2"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77faec86e3bf8e15568d026bd586e381910610544aa0b2642b942b37698029e5"
+checksum = "68de711b6da0575993b85693d9e075a014de7e66ff4c29e0c38a54376b7d426d"
 dependencies = [
  "anyhow",
  "bs58 0.3.1",

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 Install Rust, Solana, Anchor and Mocha - <br>
 https://project-serum.github.io/anchor/getting-started/installation.html
+ - solana 1.8.5
+ - anchor 0.22.0
 
 1. Clone repo
 2. Setup nvm with node v16.13.0 

--- a/build/githubactions/dockerfile
+++ b/build/githubactions/dockerfile
@@ -14,14 +14,14 @@ ENV PATH /root/.cargo/bin:$PATH
 RUN rustup component add rustfmt
 
 # Install Solana CLI
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.8.0/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.8.5/install)"
 ENV PATH /root/.local/share/solana/install/active_release/bin:$PATH
 RUN yes | solana-keygen new
 
 WORKDIR /solana-programs
 
 # Install Anchor CLI
-RUN npm i -g @project-serum/anchor-cli
+RUN npm i -g @project-serum/anchor-cli@0.22.0
 
 # Install app dependencies
 RUN npm i -g typescript

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "dependencies": {
-        "@project-serum/anchor": "^0.18.0",
-        "@solana/spl-token": "^0.1.8",
-        "buffer-layout": "^1.2.2"
+        "@project-serum/anchor": "0.22.0",
+        "@solana/spl-token": "0.1.8",
+        "buffer-layout": "1.2.2"
     },
     "devDependencies": {
         "@types/chai": "^4.2.22",

--- a/programs/dca-vault/Cargo.toml
+++ b/programs/dca-vault/Cargo.toml
@@ -16,8 +16,8 @@ cpi = ["no-entrypoint"]
 default = []
 
 [dependencies]
-anchor-lang = "0.18.0"
-anchor-spl = "0.18.2"
+anchor-lang = "0.22.0"
+anchor-spl = "0.22.0"
 spl-token = { version = "3.3.0", features = ["no-entrypoint"] }
 
 [dev-dependencies]

--- a/programs/dca-vault/src/instructions/common.rs
+++ b/programs/dca-vault/src/instructions/common.rs
@@ -1,6 +1,6 @@
 use anchor_lang::prelude::*;
 
-#[error]
+#[error_code]
 pub enum ErrorCode {
     #[msg("Granularity must be an integer larger than 0")]
     InvalidGranularity,

--- a/programs/dca-vault/src/instructions/deposit.rs
+++ b/programs/dca-vault/src/instructions/deposit.rs
@@ -1,19 +1,13 @@
+use crate::common::ErrorCode::PeriodicDripAmountIsZero;
 use crate::math::calculate_periodic_drip_amount;
 use crate::state::{Position, Vault, VaultPeriod};
-use crate::ErrorCode;
 use anchor_lang::prelude::*;
 use anchor_spl::token;
 use anchor_spl::token::{Mint, MintTo, SetAuthority, Token, TokenAccount, Transfer};
 use spl_token::instruction::AuthorityType;
 
 #[derive(AnchorSerialize, AnchorDeserialize)]
-pub struct DepositBumps {
-    position_mint: u8,
-}
-
-#[derive(AnchorSerialize, AnchorDeserialize)]
 pub struct DepositParams {
-    bumps: DepositBumps,
     token_a_deposit_amount: u64,
     dca_cycles: u64,
 }
@@ -30,9 +24,9 @@ pub struct Deposit<'info> {
             vault.token_b_mint.as_ref(),
             vault.proto_config.as_ref()
         ],
-        bump = vault.seed_bump
+        bump = vault.bump
     )]
-    pub vault: Account<'info, Vault>,
+    pub vault: Box<Account<'info, Vault>>,
 
     // TODO(matcha): Maybe move the constraint here to the handler and throw a custom error
     #[account(
@@ -44,7 +38,7 @@ pub struct Deposit<'info> {
             vault_period_end.period_id == vault.last_dca_period + params.dca_cycles
         }
     )]
-    pub vault_period_end: Account<'info, VaultPeriod>,
+    pub vault_period_end: Box<Account<'info, VaultPeriod>>,
 
     #[account(
         init,
@@ -53,43 +47,44 @@ pub struct Deposit<'info> {
             vault.key().as_ref(),
             user_position_nft_mint.key().as_ref()
         ],
-        bump = params.bumps.position_mint,
+        bump,
         payer = depositor
     )]
-    pub user_position: Account<'info, Position>,
+    pub user_position: Box<Account<'info, Position>>,
 
     // Token mints
     #[account(
-        owner = Token::id(),
-        constraint = token_a_mint.key() == vault.token_a_mint,
+        constraint = {
+            token_a_mint.to_account_info().owner == &Token::id() &&
+            token_a_mint.key() == vault.token_a_mint
+        },
     )]
-    pub token_a_mint: Account<'info, Mint>,
+    pub token_a_mint: Box<Account<'info, Mint>>,
 
     #[account(
         init,
         mint::authority = vault,
         mint::decimals = 0,
-        owner = Token::id(),
         payer = depositor
     )]
-    pub user_position_nft_mint: Account<'info, Mint>,
+    pub user_position_nft_mint: Box<Account<'info, Mint>>,
 
     // Token accounts
     #[account(
         mut,
-        owner = Token::id(),
         constraint = {
+            vault_token_a_account.to_account_info().owner == &Token::id() &&
             vault_token_a_account.mint == vault.token_a_mint &&
             vault_token_a_account.owner == vault.key()
         },
     )]
-    pub vault_token_a_account: Account<'info, TokenAccount>,
+    pub vault_token_a_account: Box<Account<'info, TokenAccount>>,
 
     // TODO(matcha): Revisit this and make sure this constraint makes sense
     #[account(
         mut,
-        owner = Token::id(),
         constraint = {
+            user_token_a_account.to_account_info().owner == &Token::id() &&
             user_token_a_account.mint == vault.token_a_mint &&
             user_token_a_account.owner == depositor.key() &&
             user_token_a_account.delegate.contains(&vault.key()) &&
@@ -97,18 +92,18 @@ pub struct Deposit<'info> {
             params.token_a_deposit_amount > 0
         }
     )]
-    pub user_token_a_account: Account<'info, TokenAccount>,
+    pub user_token_a_account: Box<Account<'info, TokenAccount>>,
 
     #[account(
         init,
-        owner = Token::id(),
         token::mint = user_position_nft_mint,
         token::authority = depositor,
         payer = depositor
     )]
-    pub user_position_nft_account: Account<'info, TokenAccount>,
+    pub user_position_nft_account: Box<Account<'info, TokenAccount>>,
 
     // Other
+    #[account(mut)]
     pub depositor: Signer<'info>,
 
     #[account(address = Token::id())]
@@ -118,7 +113,7 @@ pub struct Deposit<'info> {
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<Deposit>, params: DepositParams) -> ProgramResult {
+pub fn handler(ctx: Context<Deposit>, params: DepositParams) -> Result<()> {
     // TODO(matcha): Do validations that are not possible via eDSL
 
     // Take mutable references to init/mut accounts
@@ -130,7 +125,7 @@ pub fn handler(ctx: Context<Deposit>, params: DepositParams) -> ProgramResult {
         calculate_periodic_drip_amount(params.token_a_deposit_amount, params.dca_cycles);
 
     if periodic_drip_amount == 0 {
-        return Err(ErrorCode::PeriodicDripAmountIsZero.into());
+        return Err(PeriodicDripAmountIsZero.into());
     }
 
     // Make account modifications
@@ -144,7 +139,6 @@ pub fn handler(ctx: Context<Deposit>, params: DepositParams) -> ProgramResult {
         params.dca_cycles,
         periodic_drip_amount,
     );
-
     send_tokens(
         &ctx.accounts.token_program,
         &ctx.accounts.vault,
@@ -169,7 +163,7 @@ fn send_tokens<'info>(
     from: &Account<'info, TokenAccount>,
     to: &Account<'info, TokenAccount>,
     amount: u64,
-) -> ProgramResult {
+) -> Result<()> {
     token::transfer(
         CpiContext::new_with_signer(
             token_program.to_account_info().clone(),
@@ -189,7 +183,7 @@ fn mint_position_nft<'info>(
     vault: &Account<'info, Vault>,
     mint: &Account<'info, Mint>,
     to: &Account<'info, TokenAccount>,
-) -> ProgramResult {
+) -> Result<()> {
     // Mint NFT to user
     token::mint_to(
         CpiContext::new_with_signer(

--- a/programs/dca-vault/src/instructions/init_vault.rs
+++ b/programs/dca-vault/src/instructions/init_vault.rs
@@ -1,16 +1,9 @@
 use crate::state::{Vault, VaultProtoConfig};
 use anchor_lang::prelude::*;
+use anchor_spl::associated_token::AssociatedToken;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 
-#[derive(AnchorSerialize, AnchorDeserialize)]
-pub struct InitializeVaultBumps {
-    vault: u8,
-    token_a_account: u8,
-    token_b_account: u8,
-}
-
 #[derive(Accounts)]
-#[instruction(bumps: InitializeVaultBumps)]
 pub struct InitializeVault<'info> {
     #[account(
         init,
@@ -20,51 +13,45 @@ pub struct InitializeVault<'info> {
             token_b_mint.key().as_ref(),
             vault_proto_config.key().as_ref(),
         ],
-        bump = bumps.vault,
+        bump,
         payer = creator,
     )]
-    pub vault: Account<'info, Vault>,
+    pub vault: Box<Account<'info, Vault>>,
 
     #[account(
         init,
-        seeds = [
-            b"token_a_account".as_ref(),
-            vault.key().as_ref(),
-            token_a_mint.key().as_ref(),
-        ],
-        bump = bumps.token_a_account,
-        token::mint = token_a_mint,
-        token::authority = vault,
+        associated_token::mint = token_a_mint,
+        associated_token::authority = vault,
         payer = creator
     )]
-    pub token_a_account: Account<'info, TokenAccount>,
+    pub token_a_account: Box<Account<'info, TokenAccount>>,
 
     #[account(
         init,
-        seeds = [
-            b"token_b_account".as_ref(),
-            vault.key().as_ref(),
-            token_b_mint.key().as_ref(),
-        ],
-        bump = bumps.token_b_account,
-        token::mint = token_b_mint,
-        token::authority = vault,
+        associated_token::mint = token_b_mint,
+        associated_token::authority = vault,
         payer = creator,
     )]
-    pub token_b_account: Account<'info, TokenAccount>,
+    pub token_b_account: Box<Account<'info, TokenAccount>>,
 
-    pub token_a_mint: Account<'info, Mint>,
-    pub token_b_mint: Account<'info, Mint>,
-    pub vault_proto_config: Account<'info, VaultProtoConfig>,
+    pub token_a_mint: Box<Account<'info, Mint>>,
+
+    pub token_b_mint: Box<Account<'info, Mint>>,
+
+    pub vault_proto_config: Box<Account<'info, VaultProtoConfig>>,
+
+    #[account(mut)]
     pub creator: Signer<'info>,
 
     #[account(address = anchor_spl::token::ID)]
     pub token_program: Program<'info, Token>,
+    #[account(address = anchor_spl::associated_token::ID)]
+    pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
     pub rent: Sysvar<'info, Rent>, // TODO(matcha): Add remaining accounts here, if any
 }
 
-pub fn handler(ctx: Context<InitializeVault>, bumps: InitializeVaultBumps) -> ProgramResult {
+pub fn handler(ctx: Context<InitializeVault>) -> Result<()> {
     let vault = &mut ctx.accounts.vault;
     vault.proto_config = ctx.accounts.vault_proto_config.key();
     vault.token_a_mint = ctx.accounts.token_a_mint.key();
@@ -73,7 +60,7 @@ pub fn handler(ctx: Context<InitializeVault>, bumps: InitializeVaultBumps) -> Pr
     vault.token_b_account = ctx.accounts.token_b_account.key();
     vault.last_dca_period = 0;
     vault.drip_amount = 0;
-    vault.seed_bump = bumps.vault;
+    vault.bump = *ctx.bumps.get("vault").unwrap();
 
     let now = Clock::get().unwrap().unix_timestamp;
     // TODO(matcha): Abstract away this date flooring math and add unit tests

--- a/programs/dca-vault/src/instructions/init_vault_proto_config.rs
+++ b/programs/dca-vault/src/instructions/init_vault_proto_config.rs
@@ -3,7 +3,6 @@ use crate::state::{ByteSized, VaultProtoConfig};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
-#[instruction(bump: u8)]
 pub struct InitializeVaultProtoConfig<'info> {
     #[account(
         init,
@@ -11,11 +10,14 @@ pub struct InitializeVaultProtoConfig<'info> {
         space = 8 + VaultProtoConfig::byte_size()
     )]
     pub vault_proto_config: Account<'info, VaultProtoConfig>,
+
+    #[account(mut)]
     pub creator: Signer<'info>,
+
     pub system_program: Program<'info, System>,
 }
 
-pub fn handler(ctx: Context<InitializeVaultProtoConfig>, granularity: i64) -> ProgramResult {
+pub fn handler(ctx: Context<InitializeVaultProtoConfig>, granularity: i64) -> Result<()> {
     let config = &mut ctx.accounts.vault_proto_config;
     config.granularity = granularity;
     if granularity <= 0 {

--- a/programs/dca-vault/src/lib.rs
+++ b/programs/dca-vault/src/lib.rs
@@ -15,15 +15,15 @@ pub mod dca_vault {
     pub fn init_vault_proto_config(
         ctx: Context<InitializeVaultProtoConfig>,
         granularity: i64,
-    ) -> ProgramResult {
+    ) -> Result<()> {
         instructions::init_vault_proto_config::handler(ctx, granularity)
     }
 
-    pub fn init_vault(ctx: Context<InitializeVault>, bumps: InitializeVaultBumps) -> ProgramResult {
-        instructions::init_vault::handler(ctx, bumps)
+    pub fn init_vault(ctx: Context<InitializeVault>) -> Result<()> {
+        instructions::init_vault::handler(ctx)
     }
 
-    pub fn deposit(ctx: Context<Deposit>, params: DepositParams) -> ProgramResult {
+    pub fn deposit(ctx: Context<Deposit>, params: DepositParams) -> Result<()> {
         instructions::deposit::handler(ctx, params)
     }
 }

--- a/programs/dca-vault/src/state/vault.rs
+++ b/programs/dca-vault/src/state/vault.rs
@@ -16,7 +16,7 @@ pub struct Vault {
     pub last_dca_period: u64, // 1 to N
     pub drip_amount: u64,
     pub dca_activation_timestamp: i64,
-    pub seed_bump: u8,
+    pub bump: u8,
 }
 
 impl Vault {

--- a/tests/integration-tests/initVault.ts
+++ b/tests/integration-tests/initVault.ts
@@ -8,11 +8,12 @@ import { ProgramUtils } from "../utils/ProgramUtils";
 import { TokenUtils } from "../utils/TokenUtils";
 import { VaultUtils } from "../utils/VaultUtils";
 import { expect } from "chai";
+import {PublicKey} from "@solana/web3.js";
 
 export function testInitVault() {
   let vaultProtoConfigAccount: web3.PublicKey;
 
-  beforeEach(async () => {
+  before(async () => {
     const vaultProtoConfigKeypair = KeypairUtils.generatePair();
     await VaultUtils.initVaultProtoConfig(vaultProtoConfigKeypair, {
       granularity: Granularity.DAILY,
@@ -32,55 +33,42 @@ export function testInitVault() {
       vaultProtoConfigAccount,
     );
 
-    const [vaultTokenAAccountPDA, vaultTokenBAccountPDA] = await Promise.all([
-      PDAUtils.getTokenAccountPDA(
-        ProgramUtils.vaultProgram.programId,
-        CONSTANT_SEEDS.tokenAAccount,
-        vaultPDA.pubkey,
-        tokenA.publicKey,
-      ),
-      PDAUtils.getTokenAccountPDA(
-        ProgramUtils.vaultProgram.programId,
-        CONSTANT_SEEDS.tokenBAccount,
-        vaultPDA.pubkey,
-        tokenB.publicKey,
-      )
-    ]); 
+    const [vaultTokenA_ATA, vaultTokenB_ATA] = await Promise.all([
+      PDAUtils.findAssociatedTokenAddress(vaultPDA.pubkey as PublicKey, tokenA.publicKey),
+      PDAUtils.findAssociatedTokenAddress(vaultPDA.pubkey as PublicKey, tokenB.publicKey),
+    ]);
 
     await VaultUtils.initVault(
       vaultPDA,
       vaultProtoConfigAccount,
       tokenA.publicKey,
       tokenB.publicKey,
-      vaultTokenAAccountPDA,
-      vaultTokenBAccountPDA,
+      vaultTokenA_ATA,
+      vaultTokenB_ATA,
     );
 
     const vaultAccount = await AccountUtils.fetchVaultAccount(vaultPDA.pubkey);
-
     const [vaultTokenAAccount, vaultTokenBAccount] = await Promise.all([
-      TokenUtils.fetchTokenAccountInfo(vaultAccount.tokenAAccount),
-      TokenUtils.fetchTokenAccountInfo(vaultAccount.tokenBAccount),
+      TokenUtils.fetchTokenAccountInfo(vaultTokenA_ATA),
+      TokenUtils.fetchTokenAccountInfo(vaultTokenB_ATA),
     ]);
 
     // TODO(matcha): Somehow test vaultAccount.dcaActivationTimestamp
     ExpectUtils.expectBNToEqual(vaultAccount.lastDcaPeriod, "0");
     ExpectUtils.expectBNToEqual(vaultAccount.dripAmount, "0");
 
-    // web3.SYSVAR_CLOCK_PUBKEY
-
     ExpectUtils.batchExpectPubkeysToBeEqual(
       [vaultAccount.protoConfig, vaultProtoConfigAccount],
       [vaultAccount.tokenAMint, tokenA.publicKey],
       [vaultAccount.tokenBMint, tokenB.publicKey],
-      [vaultAccount.tokenAAccount, vaultTokenAAccountPDA.pubkey],
-      [vaultAccount.tokenBAccount, vaultTokenBAccountPDA.pubkey],
+      [vaultAccount.tokenAAccount, vaultTokenA_ATA],
+      [vaultAccount.tokenBAccount, vaultTokenB_ATA],
       [vaultTokenAAccount.mint, tokenA.publicKey],
       [vaultTokenBAccount.mint, tokenB.publicKey],
       [vaultTokenAAccount.owner, vaultPDA.pubkey],
       [vaultTokenBAccount.owner, vaultPDA.pubkey],
     );
 
-    expect(vaultAccount.seedBump.toString()).to.equal(vaultPDA.bump.toString());
+    expect(vaultAccount.bump.toString()).to.equal(vaultPDA.bump.toString());
   });
 }

--- a/tests/utils/AccountUtils.ts
+++ b/tests/utils/AccountUtils.ts
@@ -2,10 +2,11 @@ import { web3 } from "@project-serum/anchor";
 import { TestUtil } from "./config";
 import { ProgramUtils } from "./ProgramUtils";
 import { AsyncReturnType } from "./types";
+import { PublicKey } from "@solana/web3.js"
 
 export class AccountUtils extends TestUtil {
   static async fetchAccountData(pubkey: web3.PublicKey): Promise<Buffer> {
-    const account = await this.provider.connection.getAccountInfo(pubkey);
+    const account = await this.provider.connection.getAccountInfo(pubkey as PublicKey);
     return account.data;
   }
 
@@ -18,7 +19,7 @@ export class AccountUtils extends TestUtil {
        >
      > 
   {
-    return await ProgramUtils.vaultProgram.account.vaultProtoConfig.fetch(pubkey);
+    return await ProgramUtils.vaultProgram.account.vaultProtoConfig.fetch(pubkey as PublicKey);
   }
 
   static async fetchVaultAccount(
@@ -33,7 +34,7 @@ export class AccountUtils extends TestUtil {
          'tokenBAccount' |
          'lastDcaPeriod' |
          'dripAmount' |
-         'seedBump'
+         'bump'
        >
      > 
   {

--- a/tests/utils/PDAUtils.ts
+++ b/tests/utils/PDAUtils.ts
@@ -1,6 +1,7 @@
 import { web3 } from "@project-serum/anchor";
 import { TestUtil } from "./config";
 import { ProgramUtils } from "./ProgramUtils";
+import {PublicKey} from "@solana/web3.js";
 
 export type PDA = {
   pubkey: web3.PublicKey;
@@ -21,6 +22,20 @@ export class PDAUtils extends TestUtil {
       pubkey,
       bump
     }
+  }
+
+  static async findAssociatedTokenAddress(
+      walletAddress: PublicKey,
+      tokenMintAddress: PublicKey
+  ): Promise<web3.PublicKey> {
+    return (await PublicKey.findProgramAddress(
+        [
+          walletAddress.toBuffer(),
+          ProgramUtils.tokenProgram.programId.toBuffer(),
+          tokenMintAddress.toBuffer(),
+        ],
+        new PublicKey(ProgramUtils.associatedTokenProgram.programId),
+    ))[0];
   }
 
   static async getVaultPDA(tokenA: web3.PublicKey, tokenB: web3.PublicKey, protoConfig: web3.PublicKey): Promise<PDA> {

--- a/tests/utils/ProgramUtils.ts
+++ b/tests/utils/ProgramUtils.ts
@@ -1,5 +1,5 @@
 import { Program, web3, workspace } from "@project-serum/anchor";
-import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import { TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID } from "@solana/spl-token";
 import { DcaVault } from "../../target/types/dca_vault";
 import { TestUtil } from "./config";
 
@@ -15,6 +15,12 @@ export class ProgramUtils extends TestUtil {
   static get tokenProgram(): {programId: web3.PublicKey} {
     return {
       programId: TOKEN_PROGRAM_ID,
+    }
+  }
+
+  static get associatedTokenProgram(): {programId: web3.PublicKey} {
+    return {
+      programId: ASSOCIATED_TOKEN_PROGRAM_ID,
     }
   }
 }

--- a/tests/utils/VaultUtils.ts
+++ b/tests/utils/VaultUtils.ts
@@ -29,26 +29,24 @@ export class VaultUtils extends TestUtil {
     vaultProtoConfigAccount: web3.PublicKey,
     tokenAMint: web3.PublicKey,
     tokenBMint: web3.PublicKey,
-    tokenAAccountPDA: PDA,
-    tokenBAccountPDA: PDA,
+    tokenA_ATA: web3.PublicKey,
+    tokenB_ATA: web3.PublicKey,
   ): Promise<void> {
-    await ProgramUtils.vaultProgram.rpc.initVault({
-      vault: vaultPDA.bump,
-      tokenAAccount: tokenAAccountPDA.bump,
-      tokenBAccount: tokenBAccountPDA.bump,
-    }, {
-      accounts: {
-        vault: vaultPDA.pubkey.toString(),
-        vaultProtoConfig: vaultProtoConfigAccount.toString(),
-        tokenAMint: tokenAMint.toString(),
-        tokenBMint: tokenBMint.toString(),
-        tokenAAccount: tokenAAccountPDA.pubkey.toString(),
-        tokenBAccount: tokenBAccountPDA.pubkey.toString(),
-        creator: this.provider.wallet.publicKey.toString(),
-        systemProgram: ProgramUtils.systemProgram.programId.toString(),
-        tokenProgram: ProgramUtils.tokenProgram.programId.toString(),
-        rent: web3.SYSVAR_RENT_PUBKEY,
-      },
+    const accounts = {
+      vault: vaultPDA.pubkey.toString(),
+      vaultProtoConfig: vaultProtoConfigAccount.toString(),
+      tokenAMint: tokenAMint.toString(),
+      tokenBMint: tokenBMint.toString(),
+      tokenAAccount: tokenA_ATA.toString(),
+      tokenBAccount: tokenB_ATA.toString(),
+      creator: this.provider.wallet.publicKey.toString(),
+      systemProgram: ProgramUtils.systemProgram.programId.toString(),
+      tokenProgram: ProgramUtils.tokenProgram.programId.toString(),
+      associatedTokenProgram: ProgramUtils.associatedTokenProgram.programId.toString(),
+      rent: web3.SYSVAR_RENT_PUBKEY,
+    };
+    await ProgramUtils.vaultProgram.rpc.initVault( {
+      accounts: accounts,
     });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -33,17 +33,19 @@
     "@ethersproject/logger" "^5.5.0"
     hash.js "1.1.7"
 
-"@project-serum/anchor@^0.18.0":
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.18.0.tgz#867144282e59482230f797f73ee9f5634f846061"
+"@project-serum/anchor@0.22.0":
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/@project-serum/anchor/-/anchor-0.22.0.tgz#79d182851346fb46d471577c63eabdf6f199c03e"
+  integrity sha512-EJOE790pAQjm07loh7/JYzfcgfYv3SChBb2b9lhVdjjiimSEQrf3ESy+CGMAqcFAsyr699Ewj5k7RizY1y31cg==
   dependencies:
-    "@project-serum/borsh" "^0.2.2"
+    "@project-serum/borsh" "^0.2.5"
     "@solana/web3.js" "^1.17.0"
     base64-js "^1.5.1"
     bn.js "^5.1.2"
     bs58 "^4.0.1"
-    buffer-layout "^1.2.0"
+    buffer-layout "^1.2.2"
     camelcase "^5.3.1"
+    cross-fetch "^3.1.5"
     crypto-hash "^1.3.0"
     eventemitter3 "^4.0.7"
     find "^0.3.0"
@@ -52,9 +54,10 @@
     snake-case "^3.0.4"
     toml "^3.0.0"
 
-"@project-serum/borsh@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@project-serum/borsh/-/borsh-0.2.2.tgz#63e558f2d6eb6ab79086bf499dea94da3182498f"
+"@project-serum/borsh@^0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@project-serum/borsh/-/borsh-0.2.5.tgz#6059287aa624ecebbfc0edd35e4c28ff987d8663"
+  integrity sha512-UmeUkUoKdQ7rhx6Leve1SssMR/Ghv8qrEiyywyxSWg7ooV7StdpPBhciiy5eB3T0qU1BXvdRNC8TdrkxK7WC5Q==
   dependencies:
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
@@ -65,7 +68,7 @@
   dependencies:
     buffer "~6.0.3"
 
-"@solana/spl-token@^0.1.8":
+"@solana/spl-token@0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.1.8.tgz#f06e746341ef8d04165e21fc7f555492a2a0faa6"
   integrity sha512-LZmYCKcPQDtJgecvWOgT/cnoIQPWjdH+QVyzPcFvyDUiT0DiRjZaam4aqNUyvchLFhzgunv3d9xOoyE34ofdoQ==
@@ -265,7 +268,7 @@ buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
 
-buffer-layout@^1.2.0, buffer-layout@^1.2.2:
+buffer-layout@1.2.2, buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/buffer-layout/-/buffer-layout-1.2.2.tgz#b9814e7c7235783085f9ca4966a0cfff112259d5"
 
@@ -368,6 +371,13 @@ cross-fetch@^3.1.4:
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.4.tgz#9723f3a3a247bf8b89039f3a380a9244e8fa2f39"
   dependencies:
     node-fetch "2.6.1"
+
+cross-fetch@^3.1.5:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
+  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
+  dependencies:
+    node-fetch "2.6.7"
 
 crypto-hash@^1.3.0:
   version "1.3.0"
@@ -753,6 +763,13 @@ node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp-build@^4.2.0, node-gyp-build@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
@@ -924,6 +941,11 @@ toml@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 traverse-chain@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
@@ -987,6 +1009,19 @@ uuid@^3.4.0:
 uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which@2.0.2:
   version "2.0.2"


### PR DESCRIPTION
- upgrades anchor to 0.22
- changes vault token accounts from PDA's to ATA's
- renames `vault.seed_bump` to `vault.bump`
- wraps accounts in `Box` to move memory from the stack to the heap
-  move `owner` constraint to constraints (`owner` constraint no longer supported)
- Remove user provided bumps in `init_vault`
- store vault bump in the vault account
- 