### PR TITLE
`feat`: add keeper-bot setup `[DCA-78]`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "test:unit": "SWAP_PROGRAM_OWNER_FEE_ADDRESS=HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN yarn test:unit:raw",
     "test:integration": "SWAP_PROGRAM_OWNER_FEE_ADDRESS=HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN yarn test:integration:raw",
     "test:integration:detach": "SWAP_PROGRAM_OWNER_FEE_ADDRESS=HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN yarn test:integration:detach:raw",
+    "test:log:integration:detach": "LOG=true yarn test:integration:detach",
     "test": "yarn test:unit && yarn test:integration",
     "test:log": "LOG=true yarn test",
     "test:detach": "yarn test:unit && yarn test:integration:detach",
     "test:detach:log": "LOG=true yarn test:detach",
+    "test:setupkeeperbot": "SETUP_BOT=true yarn test:log:integration:detach",
     "build": "SWAP_PROGRAM_OWNER_FEE_ADDRESS=HfoTxFR1Tm6kGmWgYWD6J7YHVy1UwqSULUGVLXkJqaKN anchor build"
   }
 }

--- a/tests/dca-vault.ts
+++ b/tests/dca-vault.ts
@@ -6,8 +6,10 @@ import { testClosePosition } from "./integration-tests/closePosition";
 import { testTriggerDCA } from "./integration-tests/triggerDCA";
 import sinon from "sinon";
 import { testWithdrawB } from "./integration-tests/withdrawB";
+import { setupKeeperBot } from "./deps-test/setupKeeperBot";
 
 const DISABLE_LOGGING = !process.env.LOG;
+const SETUP_BOT = process.env.SETUP_BOT;
 
 if (DISABLE_LOGGING) {
   console.log("DISABLED LOGGING");
@@ -17,12 +19,16 @@ if (DISABLE_LOGGING) {
   sinon.stub(console, "info");
 }
 
-describe("DCA Vault Program Integration Tests", () => {
-  describe("#initVaultProtoConfig", testInitVaultProtoConfig);
-  describe("#initVault", testInitVault);
-  describe("#initVaultPeriod", testInitVaultPeriod);
-  describe("#deposit", testDeposit);
-  describe("#withdrawB", testWithdrawB);
-  describe("#closePosition", testClosePosition);
-  describe("#triggerDCA", testTriggerDCA);
-});
+if (SETUP_BOT) {
+  describe("Setup Programs for Keeper Bot", setupKeeperBot);
+} else {
+  describe("DCA Vault Program Integration Tests", () => {
+    describe("#initVaultProtoConfig", testInitVaultProtoConfig);
+    describe("#initVault", testInitVault);
+    describe("#initVaultPeriod", testInitVaultPeriod);
+    describe("#deposit", testDeposit);
+    describe("#withdrawB", testWithdrawB);
+    describe("#closePosition", testClosePosition);
+    describe("#triggerDCA", testTriggerDCA);
+  });
+}

--- a/tests/deps-test/setupKeeperBot.ts
+++ b/tests/deps-test/setupKeeperBot.ts
@@ -1,0 +1,147 @@
+import { SolUtils } from "../utils/SolUtils";
+import { TokenUtil } from "../utils/Token.util";
+import {
+  findAssociatedTokenAddress,
+  generatePairs,
+  PDA,
+} from "../utils/common.util";
+import {
+  deploySwap,
+  deployVault,
+  deployVaultPeriod,
+  deployVaultProtoConfig,
+  depositWithNewUserWrapper,
+  sleep,
+} from "../utils/setup.util";
+import { Token } from "@solana/spl-token";
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+export function setupKeeperBot() {
+  let tokenOwnerKeypair: Keypair;
+  let payerKeypair: Keypair;
+
+  let tokenA: Token;
+  let tokenB: Token;
+  let swap: PublicKey;
+  let vaultProtoConfig: PublicKey;
+  let vaultPDA: PDA;
+  let vaultPeriods: PDA[];
+  let vaultTokenA_ATA: PublicKey;
+  let vaultTokenB_ATA: PublicKey;
+
+  let swapTokenMint: PublicKey;
+  let swapTokenAAccount: PublicKey;
+  let swapTokenBAccount: PublicKey;
+  let swapFeeAccount: PublicKey;
+  let swapAuthority: PublicKey;
+
+  let depositWithNewUser;
+
+  before(async () => {
+    // https://discord.com/channels/889577356681945098/889702325231427584/910244405443715092
+    // sleep to progress to the next block
+    await sleep(500);
+
+    [tokenOwnerKeypair, payerKeypair] = generatePairs(2);
+    await Promise.all([
+      SolUtils.fundAccount(payerKeypair.publicKey, 1000000000),
+      SolUtils.fundAccount(tokenOwnerKeypair.publicKey, 1000000000),
+    ]);
+
+    console.log("tokenOwnerKeypair:", {
+      publicKey: tokenOwnerKeypair.publicKey.toString(),
+      secretKey: tokenOwnerKeypair.secretKey.toString(),
+    });
+
+    console.log("payerKeypair:", {
+      publicKey: payerKeypair.publicKey.toString(),
+      secretKey: payerKeypair.secretKey.toString(),
+    });
+
+    tokenA = await TokenUtil.createMint(
+      tokenOwnerKeypair.publicKey,
+      null,
+      6,
+      payerKeypair
+    );
+    console.log("tokenAMint:", tokenA.publicKey.toBase58());
+
+    tokenB = await TokenUtil.createMint(
+      tokenOwnerKeypair.publicKey,
+      null,
+      6,
+      payerKeypair
+    );
+    console.log("tokenBMint:", tokenB.publicKey.toBase58());
+
+    [
+      swap,
+      swapTokenMint,
+      swapTokenAAccount,
+      swapTokenBAccount,
+      swapFeeAccount,
+      swapAuthority,
+    ] = await deploySwap(
+      tokenA,
+      tokenOwnerKeypair,
+      tokenB,
+      tokenOwnerKeypair,
+      payerKeypair
+    );
+    console.log("swap:", swap.toBase58());
+    console.log("swapTokenMint:", swapTokenMint.toBase58());
+    console.log("swapTokenAAccount:", swapTokenAAccount.toBase58());
+    console.log("swapTokenBAccount:", swapTokenBAccount.toBase58());
+    console.log("swapFeeAccount:", swapFeeAccount.toBase58());
+    console.log("swapAuthority:", swapAuthority.toBase58());
+
+    vaultProtoConfig = await deployVaultProtoConfig(1);
+    console.log("vaultProtoConfig:", vaultProtoConfig.toBase58());
+
+    vaultPDA = await deployVault(
+      tokenA.publicKey,
+      tokenB.publicKey,
+      vaultProtoConfig
+    );
+    console.log("vault:", vaultPDA.publicKey.toBase58());
+
+    [vaultTokenA_ATA, vaultTokenB_ATA] = await Promise.all([
+      findAssociatedTokenAddress(vaultPDA.publicKey, tokenA.publicKey),
+      findAssociatedTokenAddress(vaultPDA.publicKey, tokenB.publicKey),
+    ]);
+    console.log("vaultTokenAAccount:", vaultTokenA_ATA.toBase58());
+    console.log("vaultTokenBAccount:", vaultTokenB_ATA.toBase58());
+
+    const numPeriods = 101;
+    vaultPeriods = await Promise.all(
+      [...Array(numPeriods).keys()].map((i) =>
+        deployVaultPeriod(
+          vaultProtoConfig,
+          vaultPDA.publicKey,
+          tokenA.publicKey,
+          tokenB.publicKey,
+          i
+        )
+      )
+    );
+    console.log(`deployed ${numPeriods} vault periods`);
+
+    depositWithNewUser = depositWithNewUserWrapper(
+      vaultPDA.publicKey,
+      tokenOwnerKeypair,
+      tokenA
+    );
+
+    for (let i = 1; i < 11; i++) {
+      await depositWithNewUser({
+        dcaCycles: i * 10,
+        newUserEndVaultPeriod: vaultPeriods[i * 10].publicKey,
+        mintAmount: i,
+      });
+    }
+  });
+
+  it("sets up keeper bot dependencies", async () => {
+    true.should.be.true();
+  });
+}

--- a/tests/utils/setup.util.ts
+++ b/tests/utils/setup.util.ts
@@ -82,7 +82,8 @@ export const deployVaultPeriod = async (
 export const depositWithNewUserWrapper = (
   vault: PublicKey,
   tokenOwnerKeypair: Keypair,
-  tokenA: Token
+  tokenA: Token,
+  shouldLog: boolean = false
 ) => {
   return async ({
     dcaCycles,
@@ -94,10 +95,20 @@ export const depositWithNewUserWrapper = (
     mintAmount: number;
   }) => {
     const user2 = generatePair();
+    if (shouldLog) {
+      console.log(
+        "user2:",
+        user2.publicKey.toBase58(),
+        user2.secretKey.toString()
+      );
+    }
     await SolUtils.fundAccount(user2.publicKey, 1000000000);
     const user2TokenAAccount = await tokenA.createAssociatedTokenAccount(
       user2.publicKey
     );
+    if (shouldLog) {
+      console.log("user2TokenAAccount:", user2TokenAAccount.toBase58());
+    }
     const user2MintAmount = await TokenUtil.scaleAmount(
       amount(mintAmount, Denom.Thousand),
       tokenA
@@ -108,7 +119,11 @@ export const depositWithNewUserWrapper = (
       [],
       user2MintAmount
     );
-    await depositToVault(
+    const [
+      user2PositionNFTMint,
+      user2PositionAccount,
+      user2PositionNFTAccount,
+    ] = await depositToVault(
       user2,
       tokenA,
       user2MintAmount,
@@ -117,6 +132,14 @@ export const depositWithNewUserWrapper = (
       newUserEndVaultPeriod,
       user2TokenAAccount
     );
+    if (shouldLog) {
+      console.log("user2PositionNFTMint:", user2PositionNFTMint.toBase58());
+      console.log("user2PositionAccount:", user2PositionAccount.toBase58());
+      console.log(
+        "user2PositionNFTAccount:",
+        user2PositionNFTAccount.toBase58()
+      );
+    }
   };
 };
 


### PR DESCRIPTION
Re-use test utils to setup programs for keeper bot tests. 

With this setup, you can copy the output of the test directly into the keeper bot config.